### PR TITLE
Detect passwords in urls with empty usernames

### DIFF
--- a/pkg/detectors/generic/url_password_detector.go
+++ b/pkg/detectors/generic/url_password_detector.go
@@ -14,7 +14,7 @@ const (
 
 	// urlPasswordRegex represents a regex that matches urls with user & password.
 	// e.g. scheme://user:pass@domain.com/
-	urlPasswordRegex = `[a-z][a-z0-9+.-]+://[^:\s]+:[^@:\s]+@[^\s'"\];]+`
+	urlPasswordRegex = `[a-z][a-z0-9+.-]+://[^:\s]*:[^@:\s]+@[^\s'"\];]+`
 )
 
 func init() {
@@ -37,7 +37,6 @@ func isUrlWithPassword(_, s string) bool {
 		return false
 	}
 
-	user := u.User.Username()
 	pwd, _ := u.User.Password()
-	return user != "" && pwd != "" && !strings.HasPrefix(pwd, "$")
+	return pwd != "" && !strings.HasPrefix(pwd, "$")
 }

--- a/pkg/detectors/generic/url_password_detector_test.go
+++ b/pkg/detectors/generic/url_password_detector_test.go
@@ -14,7 +14,7 @@ var urlPwdTestCases = []tests.TestCase{
 
 	{"missing scheme", "user:p455w0rd@example.com", false},
 	{"missing domain", "https://user:p455w0rd@", false},
-	{"empty user", "https://:p455w0rd@example.com", false},
+	{"empty user", "https://:p455w0rd@example.com", true},
 	{"empty pwd", "https://user:@example.com", false},
 	{"missing pwd", "https://user@example.com", false},
 	{"missing user & pwd", "https://example.com", false},


### PR DESCRIPTION
    Fix URL password detector to support empty usernames
    
    Update regex and verifier to correctly detect URLs with passwords
    even when the username is empty (e.g., https://:password@example.com).
    
    Changes:
    - Modified regex pattern to allow empty usernames
    - Updated verifier function to only require non-empty password
    - Fixed test case expectation for empty username scenario
    
    🤖 Generated with [Claude Code](https://claude.ai/code)
    
    Co-Authored-By: Claude <noreply@anthropic.com>