### PR TITLE
Add basic Github action workflow to run checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: build
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version: '1.21'
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v -cover ./...
+
+    - name: Lint
+      run: go vet -composites=false ./...
+
+    - name: Format
+      run: go fmt ./... && git diff --exit-code --color


### PR DESCRIPTION
I understand that you probably did not intend to take over upstream development in this fork, but as the previous upstream archived their repository, your fork becomes the most up to date version of this library.

As docker-compose now depends on your fork, I am currently packaging your library in Debian, and noticed that the testsuite does not pass.
It seems upstream developers didn't care to run the testsuite after making changes, leading to a lot of tests failing.

To prevent this situation, it is good to run the build and tests on each push and pull requests to master.

This commits adds a very basic GitHub actions workflow for go projects.

The composites check of go vet is ignored as the tests make a heavy use of unkeyed struct fields, which leaded to a lot of "struct literal uses unkeyed fields" warnings that are not that important since the package comes from the same repository.

-----

As a follow-up, I will send you some patches that fix most of the test failures, but for a few of them, I did not manage to find an easy solution yet. I will try to run `git bisect` to find where these few last failing tests stopped passing.